### PR TITLE
Potential fix for code scanning alert no. 13: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/mem0/mem0/memory/utils.py
+++ b/mem0/mem0/memory/utils.py
@@ -124,10 +124,10 @@ def process_telemetry_filters(filters):
 
     encoded_ids = {}
     if "user_id" in filters:
-        encoded_ids["user_id"] = hashlib.md5(filters["user_id"].encode()).hexdigest()
+        encoded_ids["user_id"] = hashlib.sha256(filters["user_id"].encode()).hexdigest()
     if "agent_id" in filters:
-        encoded_ids["agent_id"] = hashlib.md5(filters["agent_id"].encode()).hexdigest()
+        encoded_ids["agent_id"] = hashlib.sha256(filters["agent_id"].encode()).hexdigest()
     if "run_id" in filters:
-        encoded_ids["run_id"] = hashlib.md5(filters["run_id"].encode()).hexdigest()
+        encoded_ids["run_id"] = hashlib.sha256(filters["run_id"].encode()).hexdigest()
 
     return list(filters.keys()), encoded_ids


### PR DESCRIPTION
Potential fix for [https://github.com/DrJLabs/Forgetful/security/code-scanning/13](https://github.com/DrJLabs/Forgetful/security/code-scanning/13)

To fix the issue, replace MD5 with a strong cryptographic hashing algorithm. Since the hashed values are used for encoding IDs (not password hashing), SHA-256 is a suitable choice. It provides strong collision resistance and pre-image resistance without adding unnecessary complexity.

**Steps:**
1. Replace `hashlib.md5` with `hashlib.sha256` in the `process_telemetry_filters` function.
2. Ensure the functionality remains unchanged by continuing to hash the input encoded string and returning the hexadecimal digest.

**Required changes:**
- Modify the lines using `hashlib.md5` in `process_telemetry_filters`.
- Update the imports if needed (SHA-256 is already part of `hashlib`, so no new dependencies are required).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
