### PR TITLE
Orchestrate pull request for performance tests

### DIFF
--- a/tests/test_performance_batching.py
+++ b/tests/test_performance_batching.py
@@ -17,9 +17,10 @@ import random
 from unittest.mock import Mock, patch, AsyncMock
 from concurrent.futures import ThreadPoolExecutor
 
-# Add the workspace to the path
+# Add the workspace to the path dynamically
 import sys
-sys.path.insert(0, '/workspace')
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from shared.batching import (
     BatchConfig,

--- a/tests/test_performance_caching.py
+++ b/tests/test_performance_caching.py
@@ -20,9 +20,10 @@ from concurrent.futures import ThreadPoolExecutor
 import psutil
 import os
 
-# Add the workspace to the path
+# Add the workspace to the path dynamically
 import sys
-sys.path.insert(0, '/workspace')
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from shared.caching import (
     MultiLayerCacheConfig, 

--- a/tests/test_performance_connection_pooling.py
+++ b/tests/test_performance_connection_pooling.py
@@ -17,9 +17,10 @@ import random
 from unittest.mock import Mock, patch, AsyncMock
 from concurrent.futures import ThreadPoolExecutor
 
-# Add the workspace to the path
+# Add the workspace to the path dynamically
 import sys
-sys.path.insert(0, '/workspace')
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from shared.connection_pool import (
     ConnectionPoolConfig,


### PR DESCRIPTION
Replace hardcoded `/workspace` path in performance test files to ensure environment independence.