### PR TITLE
Fix shell command execution in markdown

### DIFF
--- a/CI_CD_REPAIR_PLAN.md
+++ b/CI_CD_REPAIR_PLAN.md
@@ -1,6 +1,6 @@
 # CI/CD Quality Gate Repair Plan
 
-**Generated:** $(date)  
+**Generated:** 2024-12-19  
 **Status:** Ready for Implementation  
 **Priority:** High - Blocking PR merges
 


### PR DESCRIPTION
Replace `$(date)` with a static date in `CI_CD_REPAIR_PLAN.md` to prevent literal display in markdown.