### PR TITLE
Fix port configuration mismatch in service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,7 +185,7 @@ services:
     env_file:
       - ./openmemory/api/.env
     ports:
-      - '127.0.0.1:${OPENMEMORY_API_PORT:-8765}:8765'
+      - '127.0.0.1:${OPENMEMORY_API_PORT:-8765}:${OPENMEMORY_API_PORT:-8765}'
     volumes:
       - ./openmemory/api:/usr/src/openmemory
     command: >


### PR DESCRIPTION
Synchronize `openmemory-mcp` Docker Compose internal port mapping with `OPENMEMORY_API_PORT` to prevent connection failures.