### PR TITLE
Restore missing system dependencies for workflows

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -159,6 +159,11 @@ jobs:
             ${{ runner.os }}-venv-${{ env.CACHE_VERSION }}-${{ matrix.python-version }}-
             ${{ runner.os }}-venv-${{ env.CACHE_VERSION }}-
 
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev netcat-openbsd
+
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,11 @@ jobs:
             ${{ runner.os }}-venv-${{ env.CACHE_VERSION }}-${{ matrix.python-version }}-
             ${{ runner.os }}-venv-${{ env.CACHE_VERSION }}-
 
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev netcat-openbsd
+
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
@@ -138,10 +143,15 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-test.txt
 
-      - name: Wait for PostgreSQL
+      - name: Wait for Services
         run: |
           until pg_isready -h localhost -p 5432; do
             echo "Waiting for PostgreSQL..."
+            sleep 2
+          done
+          
+          until nc -z localhost 7687; do
+            echo "Waiting for Neo4j..."
             sleep 2
           done
 


### PR DESCRIPTION
Re-add missing system dependencies (`libpq-dev`, `netcat-openbsd`) and enhance service wait steps in workflows to fix connection failures.