### PR TITLE
Fix environment variable syntax in .env files

### DIFF
--- a/env.template
+++ b/env.template
@@ -25,7 +25,7 @@ DATABASE_MAX_OVERFLOW=10
 DATABASE_POOL_TIMEOUT=30
 
 # Derived Variables (Auto-generated, do not modify)
-# DATABASE_URL=postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}
+# DATABASE_URL=postgresql://your_username_here:your_secure_password_here@postgres-mem0:5432/mem0
 
 # ===============================================
 # GRAPH DATABASE CONFIGURATION (Neo4j)
@@ -43,9 +43,9 @@ NEO4J_MAX_CONNECTIONS=50
 NEO4J_CONNECTION_TIMEOUT=30
 
 # Legacy Neo4j Variables (Auto-populated)
-NEO4J_AUTH=neo4j/${NEO4J_PASSWORD}
-NEO4J_URI=bolt://${NEO4J_HOST}:${NEO4J_PORT}
-NEO4J_URL=neo4j://${NEO4J_USERNAME}:${NEO4J_PASSWORD}@${NEO4J_HOST}:${NEO4J_PORT}
+NEO4J_AUTH=neo4j/your_neo4j_password_here
+NEO4J_URI=bolt://neo4j-mem0:7687
+NEO4J_URL=neo4j://neo4j:your_neo4j_password_here@neo4j-mem0:7687
 
 # ===============================================
 # OPENAI CONFIGURATION
@@ -97,8 +97,8 @@ ELASTICSEARCH_URL=http://localhost:9200
 
 # Next.js Public Environment Variables
 NEXT_PUBLIC_API_URL=http://localhost:8765
-NEXT_PUBLIC_USER_ID=${APP_USER_ID}
-NEXT_PUBLIC_ENVIRONMENT=${APP_ENVIRONMENT}
+NEXT_PUBLIC_USER_ID=your_username_here
+NEXT_PUBLIC_ENVIRONMENT=development
 
 # Build Information (Optional)
 NEXT_PUBLIC_BUILD_TIME=auto_generated
@@ -112,10 +112,10 @@ NEXT_PUBLIC_VERSION=1.0.0
 COMPOSE_PROJECT_NAME=mem0-stack
 
 # Legacy Docker Variables (Auto-populated)
-POSTGRES_USER=${DATABASE_USER}
-POSTGRES_PASSWORD=${DATABASE_PASSWORD}
-POSTGRES_DB=${DATABASE_NAME}
-USER=${APP_USER_ID}
+POSTGRES_USER=your_username_here
+POSTGRES_PASSWORD=your_secure_password_here
+POSTGRES_DB=mem0
+USER=your_username_here
 
 # ===============================================
 # ADVANCED CONFIGURATION

--- a/openmemory/api/.env.example
+++ b/openmemory/api/.env.example
@@ -19,7 +19,7 @@ DATABASE_USER=your_username_here
 DATABASE_PASSWORD=your_secure_password_here
 
 # Database URL (constructed from above variables)
-DATABASE_URL=postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}
+DATABASE_URL=postgresql://your_username_here:your_secure_password_here@postgres-mem0:5432/mem0
 
 # ===============================================
 # GRAPH DATABASE CONFIGURATION
@@ -32,11 +32,11 @@ NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=your_neo4j_password_here
 
 # Neo4j URLs (constructed from above variables)
-NEO4J_URI=bolt://${NEO4J_HOST}:${NEO4J_PORT}
-NEO4J_URL=neo4j://${NEO4J_USERNAME}:${NEO4J_PASSWORD}@${NEO4J_HOST}:${NEO4J_PORT}
+NEO4J_URI=bolt://neo4j-mem0:7687
+NEO4J_URL=neo4j://neo4j:your_neo4j_password_here@neo4j-mem0:7687
 
 # Legacy Docker Compose Variables (for backward compatibility)
-NEO4J_AUTH=neo4j/${NEO4J_PASSWORD}
+NEO4J_AUTH=neo4j/your_neo4j_password_here
 
 # ===============================================
 # OPENAI CONFIGURATION
@@ -48,7 +48,7 @@ OPENAI_MODEL=gpt-4o-mini
 OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 
 # Legacy Variable (for backward compatibility)
-API_KEY=${OPENAI_API_KEY}
+API_KEY=sk-proj-your-openai-api-key-here
 
 # ===============================================
 # APPLICATION CONFIGURATION
@@ -61,7 +61,7 @@ APP_DEBUG=true
 APP_LOG_LEVEL=INFO
 
 # Legacy Variable (for backward compatibility)
-USER=${APP_USER_ID}
+USER=your_username_here
 
 # ===============================================
 # API SERVICE CONFIGURATION


### PR DESCRIPTION
Replace shell variable expansion syntax in `.env` example files to ensure compatibility with standard parsers.