### PR TITLE
Restore all quality gates for merge decision

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -599,7 +599,7 @@ jobs:
   merge-decision:
     name: '🚦 Merge Decision (Final Quality Gate)'
     runs-on: ubuntu-latest
-    needs: [performance-tests, code-quality]
+    needs: [unit-tests, contract-tests, security-tests, database-tests, integration-tests, performance-tests, code-quality]
     if: always()
 
     steps:
@@ -613,7 +613,12 @@ jobs:
           echo "🚦 Evaluating all quality gates..."
           
           # Check if all required tests passed
-          if [ "${{ needs.performance-tests.result }}" == "success" ] && 
+          if [ "${{ needs.unit-tests.result }}" == "success" ] && 
+             [ "${{ needs.contract-tests.result }}" == "success" ] && 
+             [ "${{ needs.security-tests.result }}" == "success" ] && 
+             [ "${{ needs.database-tests.result }}" == "success" ] && 
+             [ "${{ needs.integration-tests.result }}" == "success" ] && 
+             [ "${{ needs.performance-tests.result }}" == "success" ] && 
              [ "${{ needs.code-quality.result }}" == "success" ]; then
             echo "✅ All quality gates passed - Ready for merge"
             exit 0


### PR DESCRIPTION
Fix `merge-decision` job to correctly evaluate all quality gates before allowing PR merge.

The `merge-decision` job's `needs` array and evaluation logic were incorrectly reduced, allowing pull requests to be merged even if critical tests (unit, contract, security, database, integration) failed. This change ensures all 7 quality gates must pass.