### PR TITLE
Fix Docker Compose variable substitution bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,8 +215,8 @@ services:
     environment:
       # Frontend Configuration
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8765}
-      - NEXT_PUBLIC_USER_ID=${NEXT_PUBLIC_USER_ID:-${APP_USER_ID}}
-      - NEXT_PUBLIC_ENVIRONMENT=${NEXT_PUBLIC_ENVIRONMENT:-${APP_ENVIRONMENT}}
+      - NEXT_PUBLIC_USER_ID=${NEXT_PUBLIC_USER_ID:-drj}
+      - NEXT_PUBLIC_ENVIRONMENT=${NEXT_PUBLIC_ENVIRONMENT:-development}
       - NEXT_PUBLIC_BUILD_TIME=${NEXT_PUBLIC_BUILD_TIME:-auto_generated}
       - NEXT_PUBLIC_VERSION=${NEXT_PUBLIC_VERSION:-1.0.0}
       # Application Configuration

--- a/env.template
+++ b/env.template
@@ -97,8 +97,8 @@ ELASTICSEARCH_URL=http://localhost:9200
 
 # Next.js Public Environment Variables
 NEXT_PUBLIC_API_URL=http://localhost:8765
-NEXT_PUBLIC_USER_ID=${APP_USER_ID}
-NEXT_PUBLIC_ENVIRONMENT=${APP_ENVIRONMENT}
+NEXT_PUBLIC_USER_ID=drj
+NEXT_PUBLIC_ENVIRONMENT=development
 
 # Build Information (Optional)
 NEXT_PUBLIC_BUILD_TIME=auto_generated


### PR DESCRIPTION
Fix Docker Compose variable substitution by replacing nested defaults with literal values.

Docker Compose's variable substitution for `NEXT_PUBLIC_USER_ID` and `NEXT_PUBLIC_ENVIRONMENT` was failing due to unsupported nested default value syntax, leading to incorrect resolution.