### PR TITLE
Remove redundant commit in clean_database

### DIFF
--- a/openmemory/api/conftest.py
+++ b/openmemory/api/conftest.py
@@ -100,7 +100,6 @@ def docker_postgres_engine(docker_postgres_url):
     # Create pgvector extension if not exists
     with engine.connect() as conn:
         conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
-        conn.commit()
 
     # Create all tables
     Base.metadata.create_all(bind=engine)
@@ -275,7 +274,6 @@ def migration_test_engine():
         # Create pgvector extension
         with engine.connect() as conn:
             conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
-            conn.commit()
 
         yield engine, migration_url
 


### PR DESCRIPTION
Remove redundant `conn.commit()` calls in `conftest.py` as they are incorrect for SQLAlchemy 2.0  DDL operations.

The explicit `conn.commit()` calls were redundant for `Connection` objects obtained via `engine.connect()` when executing DDL statements like `CREATE EXTENSION`. SQLAlchemy 2.0  implicitly manages or autocommits these, making the explicit commit a potential source of error.