### PR TITLE
Fix postgres healthcheck variable substitution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,16 +80,7 @@ services:
       -c 'min_wal_size=1GB' -c 'wal_buffers=64MB' -c 'default_statistics_target=100'
     networks: [traefik]
     healthcheck:
-      test:
-        [
-          'CMD',
-          'pg_isready',
-          '-q',
-          '-d',
-          '${DATABASE_NAME:-mem0}',
-          '-U',
-          '${DATABASE_USER}',
-        ]
+      test: "pg_isready -q -d ${DATABASE_NAME:-mem0} -U ${DATABASE_USER}"
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Fix postgres healthcheck in `docker-compose.yml` by converting the test command to a string to enable environment variable expansion.