### PR TITLE
Fix PYTHONPATH variable in GitHub Actions

### DIFF
--- a/github_actions_env.yml
+++ b/github_actions_env.yml
@@ -44,7 +44,7 @@ env:
   API_KEY: sk-test-key-for-mocking-only
   
   # CI-specific Configuration
-  PYTHONPATH: ${PWD}:${PWD}/openmemory/api
+  PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/openmemory/api
   CI_DATABASE_URL: postgresql://postgres:testpass@localhost:5432/test_db
   CI_NEO4J_URI: bolt://localhost:7687
   CI_COVERAGE_THRESHOLD: 80

--- a/scripts/standardize_environment.sh
+++ b/scripts/standardize_environment.sh
@@ -761,7 +761,7 @@ env:
   API_KEY: sk-test-key-for-mocking-only
   
   # CI-specific Configuration
-  PYTHONPATH: \${PWD}:\${PWD}/openmemory/api
+  PYTHONPATH: \${{ github.workspace }}:\${{ github.workspace }}/openmemory/api
   CI_DATABASE_URL: postgresql://postgres:testpass@localhost:5432/test_db
   CI_NEO4J_URI: bolt://localhost:7687
   CI_COVERAGE_THRESHOLD: 80


### PR DESCRIPTION
Fix `PYTHONPATH` expansion in GitHub Actions by using `${{ github.workspace }}` instead of `${PWD}`.

The `PYTHONPATH` variable in `github_actions_env.yml` and its generation script `standardize_environment.sh` incorrectly used shell variable syntax `${PWD}`. This prevented proper expansion in GitHub Actions, causing `PYTHONPATH` to be set as a literal string instead of the actual workspace path.