### PR TITLE
Fix PostgreSQL healthcheck command format

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,16 +80,7 @@ services:
       -c 'min_wal_size=1GB' -c 'wal_buffers=64MB' -c 'default_statistics_target=100'
     networks: [traefik]
     healthcheck:
-      test:
-        [
-          'CMD',
-          'pg_isready',
-          '-q',
-          '-d',
-          '${DATABASE_NAME:-mem0}',
-          '-U',
-          '${DATABASE_USER}',
-        ]
+      test: ["CMD-SHELL", "pg_isready -q -d ${DATABASE_NAME:-mem0} -U ${DATABASE_USER}"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Refactor PostgreSQL healthcheck to use `CMD-SHELL` format for reliable variable expansion.

The previous `CMD` array format does not reliably expand shell variables in Docker healthchecks, leading to potential failures, especially if `DATABASE_USER` contains special characters or spaces. Switching to `CMD-SHELL` ensures proper variable resolution and robust health checks.