### PR TITLE
Fix postgres service healthcheck vulnerability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,8 +82,13 @@ services:
     healthcheck:
       test:
         [
-          'CMD-SHELL',
-          'pg_isready -q -d "$${DATABASE_NAME:-mem0}" -U "$${DATABASE_USER}"',
+          'CMD',
+          'pg_isready',
+          '-q',
+          '-d',
+          '$${DATABASE_NAME:-mem0}',
+          '-U',
+          '$${DATABASE_USER}',
         ]
       interval: 5s
       timeout: 5s


### PR DESCRIPTION
Fix shell injection vulnerability in postgres healthcheck.

The `postgres` service healthcheck previously used `CMD-SHELL`, which directly interpolated `DATABASE_USER` and `DATABASE_NAME` variables, creating a shell injection vulnerability. This change switches to the safer `CMD` format, passing arguments directly and preventing shell metacharacters from being executed.