### PR TITLE
Fix postgres service healthcheck variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       test:
         [
           'CMD-SHELL',
-          'pg_isready -q -d "$${DATABASE_NAME:-mem0}" -U "$${DATABASE_USER}"'
+          'pg_isready -q -d "$${POSTGRES_DB}" -U "$${POSTGRES_USER}"'
         ]
       interval: 5s
       timeout: 5s


### PR DESCRIPTION
Fix postgres service healthcheck in docker-compose.yml to use correct environment variables.

The postgres healthcheck was failing because it referenced `DATABASE_NAME` and `DATABASE_USER`, which are not available inside the container. This PR updates the healthcheck to use the correct `POSTGRES_DB` and `POSTGRES_USER` environment variables, ensuring the healthcheck passes.