### PR TITLE
Fix pgvector extension persistence issue

### DIFF
--- a/openmemory/api/conftest.py
+++ b/openmemory/api/conftest.py
@@ -100,6 +100,7 @@ def docker_postgres_engine(docker_postgres_url):
     # Create pgvector extension if not exists
     with engine.connect() as conn:
         conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+        conn.commit()
 
     # Create all tables
     Base.metadata.create_all(bind=engine)
@@ -274,6 +275,7 @@ def migration_test_engine():
         # Create pgvector extension
         with engine.connect() as conn:
             conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+            conn.commit()
 
         yield engine, migration_url
 

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -168,6 +168,7 @@ def validate_database_connection(config: Config) -> ValidationResult:
 
             try:
                 cur.execute("CREATE EXTENSION IF NOT EXISTS vector;")
+                conn.commit()
                 cur.execute(
                     "SELECT version() FROM pg_extension WHERE extname = 'vector';"
                 )


### PR DESCRIPTION
Ensure `pgvector` extension persistence by adding explicit commits after its creation.

Removing explicit `conn.commit()` calls after `CREATE EXTENSION IF NOT EXISTS vector` can prevent the PostgreSQL `pgvector` extension from persisting. This leads to test failures where the extension is expected to be available, as DDL operations, especially in test environments or specific SQLAlchemy configurations, benefit from explicit commits to ensure persistence.