### PR TITLE
Fix cache virtual environment bug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,7 @@ jobs:
             ${{ env.CACHE_VERSION }}-pip-${{ runner.os }}-
 
       - name: Cache Virtual Environment
+        id: venv-cache
         uses: actions/cache@v4
         with:
           path: ~/venv


### PR DESCRIPTION
Add `id: venv-cache` to the virtual environment caching step to enable proper cache hit detection.

The missing `id` caused the subsequent 'Install Dependencies (optimized)' step's conditional to always evaluate as true, leading to dependencies being installed on every run and negating the caching optimization.