### PR TITLE
Fix pgvector extension persistence issue

### DIFF
--- a/openmemory/api/app/database.py
+++ b/openmemory/api/app/database.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 from dotenv import load_dotenv
 from sqlalchemy import create_engine, event, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import SQLAlchemyError
+
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 from sqlalchemy.pool import QueuePool
 

--- a/openmemory/api/setup_test_database.py
+++ b/openmemory/api/setup_test_database.py
@@ -162,6 +162,7 @@ def create_test_tables(config):
 
         # Create pgvector extension
         cursor.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        conn.commit()
 
         # Create test table
         cursor.execute(


### PR DESCRIPTION
Ensure reliable persistence of the `pgvector` extension by adding explicit `conn.commit()` after its creation.

Explicit commits are crucial after `CREATE EXTENSION IF NOT EXISTS vector` when using `engine.connect()` to prevent the extension from being rolled back or unpersisted. This addresses test failures and ensures the extension is available for subsequent vector operations.