### PR TITLE
Fix variable expansion in .env.template

### DIFF
--- a/env.template
+++ b/env.template
@@ -24,8 +24,8 @@ DATABASE_POOL_SIZE=20
 DATABASE_MAX_OVERFLOW=10
 DATABASE_POOL_TIMEOUT=30
 
-# Derived Variables (Auto-generated, do not modify)
-# DATABASE_URL=postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}
+# Derived Variables (Template - modify as needed)
+DATABASE_URL=postgresql://your_username_here:your_secure_password_here@postgres-mem0:5432/mem0
 
 # ===============================================
 # GRAPH DATABASE CONFIGURATION (Neo4j)
@@ -42,10 +42,10 @@ NEO4J_DATABASE=neo4j
 NEO4J_MAX_CONNECTIONS=50
 NEO4J_CONNECTION_TIMEOUT=30
 
-# Legacy Neo4j Variables (Auto-populated)
-NEO4J_AUTH=neo4j/${NEO4J_PASSWORD}
-NEO4J_URI=bolt://${NEO4J_HOST}:${NEO4J_PORT}
-NEO4J_URL=neo4j://${NEO4J_USERNAME}:${NEO4J_PASSWORD}@${NEO4J_HOST}:${NEO4J_PORT}
+# Legacy Neo4j Variables (Template - modify as needed)
+NEO4J_AUTH=neo4j/your_neo4j_password_here
+NEO4J_URI=bolt://neo4j-mem0:7687
+NEO4J_URL=neo4j://neo4j:your_neo4j_password_here@neo4j-mem0:7687
 
 # ===============================================
 # OPENAI CONFIGURATION
@@ -97,8 +97,8 @@ ELASTICSEARCH_URL=http://localhost:9200
 
 # Next.js Public Environment Variables
 NEXT_PUBLIC_API_URL=http://localhost:8765
-NEXT_PUBLIC_USER_ID=${APP_USER_ID}
-NEXT_PUBLIC_ENVIRONMENT=${APP_ENVIRONMENT}
+NEXT_PUBLIC_USER_ID=your_username_here
+NEXT_PUBLIC_ENVIRONMENT=development
 
 # Build Information (Optional)
 NEXT_PUBLIC_BUILD_TIME=auto_generated
@@ -111,11 +111,11 @@ NEXT_PUBLIC_VERSION=1.0.0
 # Docker Compose Project
 COMPOSE_PROJECT_NAME=mem0-stack
 
-# Legacy Docker Variables (Auto-populated)
-POSTGRES_USER=${DATABASE_USER}
-POSTGRES_PASSWORD=${DATABASE_PASSWORD}
-POSTGRES_DB=${DATABASE_NAME}
-USER=${APP_USER_ID}
+# Legacy Docker Variables (Template - modify as needed)
+POSTGRES_USER=your_username_here
+POSTGRES_PASSWORD=your_secure_password_here
+POSTGRES_DB=mem0
+USER=your_username_here
 
 # ===============================================
 # ADVANCED CONFIGURATION


### PR DESCRIPTION
Fixes `.env.template` variable expansion to enable proper environment loading.

The original `.env.template` used shell-style variable expansion (e.g., `${VAR}`) for database and other URLs. This syntax is not processed by common `.env` loaders, resulting in literal unexpanded strings and preventing successful connections. This PR updates these entries to use direct placeholder values, which users can then easily modify.