### PR TITLE
Potential fix for code scanning alert no. 582: Clear-text logging of sensitive information

### DIFF
--- a/openmemory/api/app/utils/memory.py
+++ b/openmemory/api/app/utils/memory.py
@@ -267,13 +267,13 @@ def get_memory_client(custom_instructions: str = None):
                             and mem0_config["vector_store"] is not None
                         ):
                             config["vector_store"] = mem0_config["vector_store"]
-                            print(
-                                f"Loaded vector_store config from database: {config['vector_store']['provider']}"
+                            logger.info(
+                                f"Loaded vector_store provider from database: {config['vector_store']['provider']}"
                             )
                         else:
                             # Ensure we're using pgvector as default, not qdrant
-                            print(
-                                f"No vector_store config in database, using pgvector default: {config['vector_store']['provider']}"
+                            logger.info(
+                                "No vector_store config in database, using default provider: pgvector"
                             )
 
                         # Update LLM configuration if available


### PR DESCRIPTION
Potential fix for [https://github.com/DrJLabs/Forgetful/security/code-scanning/582](https://github.com/DrJLabs/Forgetful/security/code-scanning/582)

To fix the issue, sensitive data should be excluded or sanitized before being logged. Instead of directly logging the `config['vector_store']` dictionary, only non-sensitive information (e.g., the provider name) should be logged. This ensures that no passwords or other sensitive details are inadvertently exposed. Additionally, we should replace all `print` statements with the existing structured `logger` to maintain consistency and enhance security by leveraging the logging framework's features.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
