### PR TITLE
Potential fix for code scanning alert no. 624: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/openmemory/api/app/utils/memory.py
+++ b/openmemory/api/app/utils/memory.py
@@ -52,7 +52,7 @@ _config_hash = None
 def _get_config_hash(config_dict):
     """Generate a hash of the config to detect changes."""
     config_str = json.dumps(config_dict, sort_keys=True)
-    return hashlib.md5(config_str.encode()).hexdigest()  # noqa: S324
+    return hashlib.sha256(config_str.encode()).hexdigest()
 
 
 def _get_docker_host_url():


### PR DESCRIPTION
Potential fix for [https://github.com/DrJLabs/Forgetful/security/code-scanning/624](https://github.com/DrJLabs/Forgetful/security/code-scanning/624)

To fix the issue, we should replace the weak MD5 hashing algorithm with a stronger cryptographic hash function such as SHA-256, which is part of the SHA-2 family and recommended for its resistance to collision attacks. Switching to SHA-256 ensures that the hash is more secure and aligns with modern security standards.

Steps to fix:
1. Replace the `hashlib.md5` function call with `hashlib.sha256` in the `_get_config_hash` function.
2. Update the relevant line in `openmemory/api/app/utils/memory.py` to generate the SHA-256 hash of the configuration string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
