### PR TITLE
Potential fix for code scanning alert no. 13: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/mem0/mem0/memory/utils.py
+++ b/mem0/mem0/memory/utils.py
@@ -124,10 +124,10 @@ def process_telemetry_filters(filters):
 
     encoded_ids = {}
     if "user_id" in filters:
-        encoded_ids["user_id"] = hashlib.md5(filters["user_id"].encode()).hexdigest()
+        encoded_ids["user_id"] = hashlib.sha256(filters["user_id"].encode()).hexdigest()
     if "agent_id" in filters:
-        encoded_ids["agent_id"] = hashlib.md5(filters["agent_id"].encode()).hexdigest()
+        encoded_ids["agent_id"] = hashlib.sha256(filters["agent_id"].encode()).hexdigest()
     if "run_id" in filters:
-        encoded_ids["run_id"] = hashlib.md5(filters["run_id"].encode()).hexdigest()
+        encoded_ids["run_id"] = hashlib.sha256(filters["run_id"].encode()).hexdigest()
 
     return list(filters.keys()), encoded_ids


### PR DESCRIPTION
Potential fix for [https://github.com/DrJLabs/Forgetful/security/code-scanning/13](https://github.com/DrJLabs/Forgetful/security/code-scanning/13)

To fix the issue, we will replace the use of the MD5 hashing algorithm with a stronger and more secure hashing algorithm. For general-purpose hashing, SHA-256 (from the `hashlib` library) is a suitable replacement. If the hashes are used for password storage or other sensitive contexts, a computationally expensive algorithm like Argon2, bcrypt, or PBKDF2 should be used. However, since the context here appears to be telemetry filters, SHA-256 is appropriate.

The changes involve:
1. Replacing `hashlib.md5` with `hashlib.sha256` in the `process_telemetry_filters` function in `mem0/mem0/memory/utils.py`.
2. Ensuring that the functionality remains the same, i.e., the hashed values are still returned as hexadecimal strings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
